### PR TITLE
feat: expand scan-style.sh with deterministic + qualitative checks

### DIFF
--- a/.claude/skills/ci-style-review/SKILL.md
+++ b/.claude/skills/ci-style-review/SKILL.md
@@ -35,12 +35,13 @@ Use your file-reading tool to load the full content of every file under review. 
 
 ### Step 4: Qualitative review
 
-For each file, apply the complete style criteria from Step 1. Pay special attention to:
+The scan script handles pattern-matchable violations. Your job in this step is to find issues that require reading comprehension. These are documented in the "Qualitative Checks" section of `style-review/SKILL.md`. Focus on:
 
-- **Gray-label violations** (blocker): Vendasta mentions, Partner Center, partner/reseller/agency/white-label
-- **Evergreen violations** (warning): historical references, future-state language
-- **Voice issues** (warning): third-person, passive voice, marketing language
-- **Formatting issues** (suggestion): em dashes, UI elements not in backticks
+- **Subtle evergreen language** (warning): phrases that imply change without using banned keywords
+- **Alt text quality** (suggestion): generic or non-descriptive image alt text
+- **Link text quality** (suggestion): "click here", bare URLs, or other non-descriptive anchors
+- **Wall-of-text paragraphs** (suggestion): paragraphs exceeding ~5 sentences or ~150 words
+- **FAQ answer quality** (warning): vague hedging, overly long answers, voice/tone shifts
 
 **Multiple violations on the same line:** If a single line has multiple distinct violations (e.g., a Vendasta mention AND historical language), emit separate findings for each. The post-processing pipeline handles multiple findings per line. Do not merge different violation types into a single finding.
 

--- a/.claude/skills/ci-style-review/SKILL.md
+++ b/.claude/skills/ci-style-review/SKILL.md
@@ -42,6 +42,8 @@ The scan script handles pattern-matchable violations. Your job in this step is t
 - **Link text quality** (suggestion): "click here", bare URLs, or other non-descriptive anchors
 - **Wall-of-text paragraphs** (suggestion): paragraphs exceeding ~5 sentences or ~150 words
 - **FAQ answer quality** (warning): vague hedging, overly long answers, voice/tone shifts
+- **Callout block misuse** (suggestion): block type doesn't match content (e.g. `:::warning` for a tip)
+- **Heading-content mismatch** (suggestion): heading promises one thing but body discusses another, or heading is too vague
 
 **Multiple violations on the same line:** If a single line has multiple distinct violations (e.g., a Vendasta mention AND historical language), emit separate findings for each. The post-processing pipeline handles multiple findings per line. Do not merge different violation types into a single finding.
 

--- a/.claude/skills/ci-style-review/SKILL.md
+++ b/.claude/skills/ci-style-review/SKILL.md
@@ -44,6 +44,7 @@ The scan script handles pattern-matchable violations. Your job in this step is t
 - **FAQ answer quality** (warning): vague hedging, overly long answers, voice/tone shifts
 - **Callout block misuse** (suggestion): block type doesn't match content (e.g. `:::warning` for a tip)
 - **Heading-content mismatch** (suggestion): heading promises one thing but body discusses another, or heading is too vague
+- **Subtle gray-label framing** (warning): the scan catches literal mentions of Vendasta, Partner Center, and partner/reseller/agency terms, but reviewers should still watch for indirect partner-provider framing that regex cannot detect (e.g., "your provider configured this for you")
 
 **Multiple violations on the same line:** If a single line has multiple distinct violations (e.g., a Vendasta mention AND historical language), emit separate findings for each. The post-processing pipeline handles multiple findings per line. Do not merge different violation types into a single finding.
 

--- a/.claude/skills/style-review/SKILL.md
+++ b/.claude/skills/style-review/SKILL.md
@@ -28,10 +28,13 @@ bash .claude/skills/style-review/scripts/scan-style.sh [path-or-nothing-for-modi
 The script checks for:
 - Gray-label violations (Vendasta mentions, Partner Center, partner/reseller/agency terms)
 - Evergreen violations (historical references, future-state language)
-- Voice issues (third-person, passive voice)
-- Marketing language
+- Voice issues (third-person, passive voice, marketing language, speculation)
+- Heading formatting (sentence case, H1 in body, menu path separators)
 - Formatting issues (em dashes, UI elements not in inline code)
-- Image issues (missing alt text, non-kebab-case filenames)
+- Image conventions (missing alt text, non-kebab-case filenames, images outside `./img/`)
+- Link conventions (HTTP links, absolute internal links)
+- Frontmatter recommended fields (`sidebar_label`, `description`)
+- Build safety (missing title, unquoted colons, JSX in `.md`, unclosed blocks)
 
 ### Step 3: Qualitative review
 

--- a/.claude/skills/style-review/SKILL.md
+++ b/.claude/skills/style-review/SKILL.md
@@ -185,11 +185,34 @@ Use for all UI elements:
 
 ---
 
+### Qualitative Checks (Reviewer Judgment Required)
+
+These issues cannot be caught by regex and require reading comprehension. Automated scans skip them.
+
+**Subtle evergreen violations** (warning)
+Language that implies change without using the banned keywords already listed above: "the new dashboard", "now supports", "recently added", "updated to include", "we've added", "you can now". These betray that something changed, which violates the evergreen principle.
+
+**Alt text quality** (suggestion)
+Images where alt text is generic or non-descriptive: single words like "screenshot", "image", "picture", "example", or text that doesn't describe what the image shows. Suggest a descriptive alternative based on the surrounding context.
+
+**Link text quality** (suggestion)
+Links with non-descriptive anchor text: "click here", "here", "this link", "link", "read more", or bare URLs used as the visible text. Suggest anchor text that tells the reader what they'll find at the destination.
+
+**Wall-of-text paragraphs** (suggestion)
+Paragraphs exceeding ~5 sentences or ~150 words without a visual break. The right way to split depends on context: a sub-heading, bullet list, callout block, image reference, or simply shorter paragraphs.
+
+---
+
 ### FAQs
 
-- 3–10 FAQs per article using collapsible `<details>` format
-- Answers: 1–3 sentences, no speculation, no "it depends" answers
+- 3-10 FAQs per article using collapsible `<details>` format
 - Same voice and style as main content
+
+**FAQ answer quality** (warning)
+- Answers that dodge the question with vague hedging instead of giving a concrete answer
+- Answers exceeding 3 sentences
+- Answers that shift voice/tone away from the article's style
+- Note: words like "might" or "depends" are fine when factually accurate ("results might take up to 24 hours") -- the issue is when they replace a real answer ("it depends on your setup")
 
 ```markdown
 <details>

--- a/.claude/skills/style-review/SKILL.md
+++ b/.claude/skills/style-review/SKILL.md
@@ -201,6 +201,12 @@ Links with non-descriptive anchor text: "click here", "here", "this link", "link
 **Wall-of-text paragraphs** (suggestion)
 Paragraphs exceeding ~5 sentences or ~150 words without a visual break. The right way to split depends on context: a sub-heading, bullet list, callout block, image reference, or simply shorter paragraphs.
 
+**Callout block misuse** (suggestion)
+`:::warning` used for tips or general info, `:::info` used for limitations or requirements, `:::tip` used for restrictions. Match the block type to the content: `:::warning` for limitations and requirements, `:::info` for helpful context, `:::tip` for best practices, `:::note` for plan restrictions or behavior caveats.
+
+**Heading-content mismatch** (suggestion)
+A section heading that promises one thing but the body discusses something else, or headings too vague to be useful: "More information", "Other details", "Additional notes", "Miscellaneous". Suggest a heading that accurately describes the section's actual content.
+
 ---
 
 ### FAQs

--- a/.claude/skills/style-review/scripts/scan-style.sh
+++ b/.claude/skills/style-review/scripts/scan-style.sh
@@ -331,19 +331,38 @@ run_check \
 run_check \
   "UI elements not in inline code (button/tab/field names)" \
   "warning" \
-  "Click (Save|Cancel|Submit|Connect|Continue|Next|Back|Done|OK|Yes|No|Delete|Edit|Add|Remove|Create|Update|Send|Apply)[^'\`]"
+  "Click (Save|Cancel|Submit|Connect|Continue|Next|Back|Done|OK|Yes|No|Delete|Edit|Add|Remove|Create|Update|Send|Apply)([^'\`]|$)"
 
 run_check \
   "UI elements not in backticks (expanded verbs)" \
   "warning" \
-  "(Go to|Select|Open|Navigate to|Choose|Tap) (Settings|Dashboard|Reports|Tools|Integrations|Notifications|Profile|Accounts|Analytics|Overview|Home|Inbox|Calendar|Contacts|Billing|Help)[^'\`]"
+  "(Go to|Select|Open|Navigate to|Choose|Tap) (Settings|Dashboard|Reports|Tools|Integrations|Notifications|Profile|Accounts|Analytics|Overview|Home|Inbox|Calendar|Contacts|Billing|Help)([^'\`]|$)"
 
 check_h1_in_body
 
-run_check \
-  "Heading sentence case (words after first should be lowercase)" \
-  "warning" \
-  "^#{2,3} [A-Za-z]+ (A[^n ]|B[^u]|[CDEFHIJKLMNOPQRSTUVWXYZ])[a-z]"
+# Heading sentence case — custom check with exclusion list to reduce false positives
+check_heading_sentence_case() {
+  local results
+  results=$(printf '%s\n' "${FILES[@]}" \
+    | xargs grep -nE "^#{2,3} [A-Za-z]+ (A[^n ]|B[^u]|[CDEFHIJKLMNOPQRSTUVWXYZ])[a-z]" 2>/dev/null || true)
+  if [ -n "$results" ]; then
+    # Filter out known acceptable patterns:
+    #   Standard section names, product/brand proper nouns, common doc headings
+    results=$(echo "$results" | grep -ivE \
+      "Frequently Asked|Best Practices|How It Works|Getting Started|Related Articles|Next Steps|Need Help|Key (Concepts|Capabilities|Features|Benefits)|What You|For (Outlook|Chrome|Gmail|Safari|Firefox|Mac|Windows|Android|iOS)" \
+      | grep -ivE \
+      "Google|Facebook|Instagram|LinkedIn|WordPress|Salesforce|Outlook|Microsoft|YouTube|Twitter|Yelp|TripAdvisor|Apple|Amazon|Bing|Yahoo|Pinterest|Snapchat|TikTok|QuickBooks|Shopify|HubSpot|Mailchimp|Zapier|Stripe|PayPal|ActiveCampaign|Custom CSS" \
+      || true)
+  fi
+  if [ -n "$results" ]; then
+    yellow "  WARN — Heading sentence case (words after first should be lowercase)"
+    echo "$results" | sed 's/^/    /'
+    WARNINGS=$((WARNINGS + $(echo "$results" | wc -l)))
+  else
+    green "  PASS — Heading sentence case (words after first should be lowercase)"
+  fi
+}
+check_heading_sentence_case
 
 run_check \
   "Menu path without backticks or wrong separator" \
@@ -366,7 +385,7 @@ run_check \
 run_check \
   "Images outside ./img/ directory" \
   "warning" \
-  "!\[.*\]\(\.\./|\!\[.*\]\(\./images/|!\[.*\]\(\./img/.*/|!\[.*\]\(/img/"
+  "!\[.*\]\(\.\./|!\[.*\]\(\./images/|!\[.*\]\(\./img/.*/|!\[.*\]\(/img/"
 
 # ── Frontmatter ──────────────────────────────────────────────────────────────
 echo ""

--- a/.claude/skills/style-review/scripts/scan-style.sh
+++ b/.claude/skills/style-review/scripts/scan-style.sh
@@ -88,6 +88,74 @@ run_check_icase() {
   fi
 }
 
+# ── Custom check: H1 in body (skips frontmatter) ────────────────────────────
+check_h1_in_body() {
+  local results=""
+  for f in "${FILES[@]}"; do
+    local in_frontmatter=0 past_frontmatter=0 line_num=0
+    while IFS= read -r line; do
+      line_num=$((line_num + 1))
+      if [ "$line" = "---" ]; then
+        if [ $in_frontmatter -eq 1 ]; then
+          past_frontmatter=1
+          in_frontmatter=0
+          continue
+        elif [ $past_frontmatter -eq 0 ]; then
+          in_frontmatter=1
+          continue
+        fi
+      fi
+      if [ $past_frontmatter -eq 1 ] && echo "$line" | grep -qE '^# [^#]'; then
+        results+="$f:$line_num:$line"$'\n'
+      fi
+    done < "$f"
+  done
+  results="${results%$'\n'}"
+  if [ -n "$results" ]; then
+    yellow "  WARN — H1 in body (Docusaurus uses frontmatter title as H1)"
+    echo "$results" | sed 's/^/    /'
+    WARNINGS=$((WARNINGS + $(echo "$results" | wc -l)))
+  else
+    green "  PASS — H1 in body (Docusaurus uses frontmatter title as H1)"
+  fi
+}
+
+# ── Custom check: frontmatter recommended fields ────────────────────────────
+check_frontmatter_fields() {
+  local results=""
+  for f in "${FILES[@]}"; do
+    local in_frontmatter=0 has_sidebar_label=0 has_description=0
+    while IFS= read -r line; do
+      if [ "$line" = "---" ]; then
+        if [ $in_frontmatter -eq 1 ]; then
+          break
+        else
+          in_frontmatter=1
+          continue
+        fi
+      fi
+      if [ $in_frontmatter -eq 1 ]; then
+        echo "$line" | grep -qE '^sidebar_label:' && has_sidebar_label=1
+        echo "$line" | grep -qE '^description:' && has_description=1
+      fi
+    done < "$f"
+    if [ $has_sidebar_label -eq 0 ]; then
+      results+="$f: missing sidebar_label"$'\n'
+    fi
+    if [ $has_description -eq 0 ]; then
+      results+="$f: missing description"$'\n'
+    fi
+  done
+  results="${results%$'\n'}"
+  if [ -n "$results" ]; then
+    yellow "  WARN — Frontmatter recommended fields (sidebar_label, description)"
+    echo "$results" | sed 's/^/    /'
+    WARNINGS=$((WARNINGS + $(echo "$results" | wc -l)))
+  else
+    green "  PASS — Frontmatter recommended fields (sidebar_label, description)"
+  fi
+}
+
 # ── CRITICAL: Gray-label ─────────────────────────────────────────────────────
 echo ""
 bold "[ CRITICAL ] Gray-label / branding"
@@ -155,6 +223,23 @@ run_check \
   "warning" \
   "Click (Save|Cancel|Submit|Connect|Continue|Next|Back|Done|OK|Yes|No|Delete|Edit|Add|Remove|Create|Update|Send|Apply)[^'\`]"
 
+run_check \
+  "UI elements not in backticks (expanded verbs)" \
+  "warning" \
+  "(Go to|Select|Open|Navigate to|Choose|Tap) (Settings|Dashboard|Reports|Tools|Integrations|Notifications|Profile|Accounts|Analytics|Overview|Home|Inbox|Calendar|Contacts|Billing|Help)[^'\`]"
+
+check_h1_in_body
+
+run_check \
+  "Heading sentence case (words after first should be lowercase)" \
+  "warning" \
+  "^#{2,3} [A-Za-z]+ (A[^n ]|B[^u]|[CDEFHIJKLMNOPQRSTUVWXYZ])[a-z]"
+
+run_check \
+  "Menu path without backticks or wrong separator" \
+  "warning" \
+  "(->|>>| — )[A-Z][a-z]"
+
 # ── Images ─────────────────────────────────────────────────────────────────────
 echo ""
 bold "[ IMAGES ] Image conventions"
@@ -167,6 +252,29 @@ run_check \
   "Non-kebab-case image filenames" \
   "warning" \
   "!\[.*\]\(.*[A-Z_].*\.(png|jpg|gif)\)"
+
+run_check \
+  "Images outside ./img/ directory" \
+  "warning" \
+  "!\[.*\]\(\.\./|\!\[.*\]\(\./images/|!\[.*\]\(\./img/.*/|!\[.*\]\(/img/"
+
+# ── Frontmatter ──────────────────────────────────────────────────────────────
+echo ""
+bold "[ FRONTMATTER ] Recommended frontmatter fields"
+check_frontmatter_fields
+
+# ── Links ─────────────────────────────────────────────────────────────────────
+echo ""
+bold "[ LINKS ] Link conventions"
+run_check \
+  "HTTP links (use HTTPS)" \
+  "warning" \
+  "\]\(http://"
+
+run_check \
+  "Absolute internal links (use relative paths)" \
+  "warning" \
+  "\]\(/docs/"
 
 # ── Summary ────────────────────────────────────────────────────────────────────
 echo ""

--- a/.claude/skills/style-review/scripts/scan-style.sh
+++ b/.claude/skills/style-review/scripts/scan-style.sh
@@ -88,6 +88,116 @@ run_check_icase() {
   fi
 }
 
+# ── Custom check: missing frontmatter title (BUILD-SAFETY) ───────────────────
+check_frontmatter_title() {
+  local results=""
+  for f in "${FILES[@]}"; do
+    local in_frontmatter=0 has_title=0
+    while IFS= read -r line; do
+      if [ "$line" = "---" ]; then
+        if [ $in_frontmatter -eq 1 ]; then
+          break
+        else
+          in_frontmatter=1
+          continue
+        fi
+      fi
+      if [ $in_frontmatter -eq 1 ]; then
+        echo "$line" | grep -qE '^title:' && has_title=1
+      fi
+    done < "$f"
+    if [ $in_frontmatter -eq 0 ] || [ $has_title -eq 0 ]; then
+      results+="$f: missing title in frontmatter"$'\n'
+    fi
+  done
+  results="${results%$'\n'}"
+  if [ -n "$results" ]; then
+    red "  FAIL — Missing frontmatter title (breaks build)"
+    echo "$results" | sed 's/^/    /'
+    ERRORS=$((ERRORS + $(echo "$results" | wc -l)))
+  else
+    green "  PASS — Missing frontmatter title (breaks build)"
+  fi
+}
+
+# ── Custom check: unquoted colons in frontmatter values (BUILD-SAFETY) ───────
+check_frontmatter_colons() {
+  local results=""
+  for f in "${FILES[@]}"; do
+    local in_frontmatter=0 line_num=0
+    while IFS= read -r line; do
+      line_num=$((line_num + 1))
+      if [ "$line" = "---" ]; then
+        if [ $in_frontmatter -eq 1 ]; then
+          break
+        else
+          in_frontmatter=1
+          continue
+        fi
+      fi
+      if [ $in_frontmatter -eq 1 ]; then
+        # Only check known string fields: title, sidebar_label, description
+        if echo "$line" | grep -qE '^(title|sidebar_label|description): '; then
+          # Extract the value (everything after "key: ")
+          local value
+          value=$(echo "$line" | sed 's/^[a-z_]*: //')
+          # Check if value contains a colon and is NOT quoted
+          if echo "$value" | grep -qF ':'; then
+            if ! echo "$value" | grep -qE '^".*"$' && ! echo "$value" | grep -qE "^'.*'$"; then
+              results+="$f:$line_num:$line"$'\n'
+            fi
+          fi
+        fi
+      fi
+    done < "$f"
+  done
+  results="${results%$'\n'}"
+  if [ -n "$results" ]; then
+    red "  FAIL — Unquoted colons in frontmatter values (breaks YAML parsing)"
+    echo "$results" | sed 's/^/    /'
+    ERRORS=$((ERRORS + $(echo "$results" | wc -l)))
+  else
+    green "  PASS — Unquoted colons in frontmatter values (breaks YAML parsing)"
+  fi
+}
+
+# ── Custom check: unclosed code blocks and callout blocks (BUILD-SAFETY) ─────
+check_unclosed_blocks() {
+  local code_results="" callout_results=""
+  for f in "${FILES[@]}"; do
+    # Count triple-backtick lines
+    local code_count
+    code_count=$(grep -cE '^\x60\x60\x60' "$f" 2>/dev/null) || code_count=0
+    if [ $((code_count % 2)) -ne 0 ]; then
+      code_results+="$f: $code_count triple-backtick lines (odd — likely unclosed)"$'\n'
+    fi
+    # Count ::: lines
+    local callout_count
+    callout_count=$(grep -cE '^:::' "$f" 2>/dev/null) || callout_count=0
+    if [ $((callout_count % 2)) -ne 0 ]; then
+      callout_results+="$f: $callout_count ::: lines (odd — likely unclosed)"$'\n'
+    fi
+  done
+  code_results="${code_results%$'\n'}"
+  callout_results="${callout_results%$'\n'}"
+
+  if [ -n "$code_results" ]; then
+    yellow "  WARN — Unclosed code blocks (odd number of triple-backtick lines)"
+    echo "$code_results" | sed 's/^/    /'
+    WARNINGS=$((WARNINGS + $(echo "$code_results" | wc -l)))
+  else
+    green "  PASS — Unclosed code blocks (odd number of triple-backtick lines)"
+  fi
+
+  if [ -n "$callout_results" ]; then
+    yellow "  WARN — Unclosed callout blocks (odd number of ::: lines)"
+    echo "$callout_results" | sed 's/^/    /'
+    WARNINGS=$((WARNINGS + $(echo "$callout_results" | wc -l)))
+  else
+    green "  PASS — Unclosed callout blocks (odd number of ::: lines)"
+  fi
+}
+
 # ── Custom check: H1 in body (skips frontmatter) ────────────────────────────
 check_h1_in_body() {
   local results=""
@@ -275,6 +385,34 @@ run_check \
   "Absolute internal links (use relative paths)" \
   "warning" \
   "\]\(/docs/"
+
+# ── BUILD-SAFETY ──────────────────────────────────────────────────────────────
+echo ""
+bold "[ BUILD-SAFETY ] Checks that prevent Cloud Build failures"
+check_frontmatter_title
+
+check_frontmatter_colons
+
+# JSX / Wistia in .md files (not .mdx)
+MD_ONLY=()
+for f in "${FILES[@]}"; do
+  [[ "$f" == *.md ]] && [[ "$f" != *.mdx ]] && MD_ONLY+=("$f")
+done
+if [ ${#MD_ONLY[@]} -gt 0 ]; then
+  local_results=$(printf '%s\n' "${MD_ONLY[@]}" \
+    | xargs grep -nE '<iframe|<WistiaVideo|^import |className=' 2>/dev/null || true)
+  if [ -n "$local_results" ]; then
+    red "  FAIL — JSX/Wistia in .md files (must use .mdx for JSX content)"
+    echo "$local_results" | sed 's/^/    /'
+    ERRORS=$((ERRORS + $(echo "$local_results" | wc -l)))
+  else
+    green "  PASS — JSX/Wistia in .md files (must use .mdx for JSX content)"
+  fi
+else
+  green "  PASS — JSX/Wistia in .md files (no .md files to check)"
+fi
+
+check_unclosed_blocks
 
 # ── Summary ────────────────────────────────────────────────────────────────────
 echo ""


### PR DESCRIPTION
## Summary

- Adds 8 new deterministic checks to `scan-style.sh`: frontmatter metadata, heading structure, image conventions, link conventions, and 5 BUILD-SAFETY checks that catch Cloud Build failures before push
- Adds 7 qualitative (reading-comprehension) checks to `ci-style-review/SKILL.md` for the Gemini reviewer: subtle evergreen language, alt text quality, link text quality, wall-of-text paragraphs, FAQ answer quality, callout block misuse, heading-content mismatch
- Adds the same 2 new qualitative checks (callout block misuse, heading-content mismatch) to the interactive `style-review/SKILL.md`

## Test plan

- [x] `scan-style.sh` runs cleanly on real docs with no false coupling to qualitative checks
- [x] JSON output schema and contract in `ci-style-review` unchanged
- [x] All new deterministic checks produce correct output on sample files
- [ ] Gemini CI workflow picks up qualitative checks on next triggered review

Generated with [Claude Code](https://claude.com/claude-code)